### PR TITLE
Modification to support a kops installed Kubernetes

### DIFF
--- a/cfg/1.8/master.yaml
+++ b/cfg/1.8/master.yaml
@@ -55,7 +55,7 @@ groups:
   - id: 1.1.4
     text: "Ensure that the --kubelet-https argument is set to true (Scored)"
     audit: "ps -ef | grep $apiserverbin | grep -v grep"
-    tests: 
+    tests:
       bin_op: or
       test_items:
       - flag: "--kubelet-https"
@@ -102,7 +102,7 @@ groups:
   - id: 1.1.7
     text: "Ensure that the --secure-port argument is not set to 0 (Scored)"
     audit: "ps -ef | grep $apiserverbin | grep -v grep"
-    tests: 
+    tests:
       bin_op: or
       test_items:
         - flag:  "--secure-port"
@@ -158,7 +158,7 @@ groups:
       - flag: "--admission-control"
         compare:
           op: nothave
-          value: AlwaysAdmit 
+          value: AlwaysAdmit
         set: true
     remediation: |
       Edit the API server pod specification file $apiserverconf
@@ -417,7 +417,7 @@ groups:
     scored: true
 
   - id: 1.1.26
-    text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as 
+    text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as
       appropriate (Scored"
     audit: "ps -ef | grep $apiserverbin | grep -v grep"
     tests:
@@ -743,22 +743,11 @@ groups:
     set to 644 or more restrictive (Scored)"
     audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %a $apiserverconf; fi'"
     tests:
-      bin_op: or
       test_items:
-      - flag: "644"
+      - flag: ""
         compare:
-          op: eq
-          value: "644"
-        set: true
-      - flag: "640"
-        compare:
-          op: eq
-          value: "640"
-        set: true
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
+          op: lte
+          value: 644
         set: true
     remediation: |
       Run the below command (based on the file location on your system) on the master node.
@@ -788,22 +777,11 @@ groups:
     permissions are set to 644 or more restrictive (Scored)"
     audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %a $controllermanagerconf; fi'"
     tests:
-      bin_op: or
       test_items:
-      - flag: "644"
+      - flag: ""
         compare:
-          op: eq
-          value: "644"
-        set: true
-      - flag: "640"
-        compare:
-          op: eq
-          value: "640"
-        set: true
-      - flag: "600"
-        compare:
-          op: eq
-          value: "600"
+          op: lte
+          value: 644
         set: true
     remediation: |
       Run the below command (based on the file location on your system) on the master node.
@@ -833,22 +811,11 @@ groups:
     to 644 or more restrictive (Scored)"
     audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %a $schedulerconf; fi'"
     tests:
-      bin_op: or
       test_items:
-        - flag: "644"
+        - flag: ""
           compare:
-            op: eq
-            value: "644"
-          set: true
-        - flag: "640"
-          compare:
-            op: eq
-            value: "640"
-          set: true
-        - flag: "600"
-          compare:
-            op: eq
-            value: "600"
+            op: lte
+            value: 644
           set: true
     remediation: |
       Run the below command (based on the file location on your system) on the master node.
@@ -878,22 +845,11 @@ groups:
     644 or more restrictive (Scored)"
     audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %a $etcdconf; fi'"
     tests:
-      bin_op: or
       test_items:
-        - flag: "644"
+        - flag: ""
           compare:
-            op: eq
-            value: "644"
-          set: true
-        - flag: "640"
-          compare:
-            op: eq
-            value: "640"
-          set: true
-        - flag: "600"
-          compare:
-            op: eq
-            value: "600"
+            op: lte
+            value: 644
           set: true
     remediation: |
       Run the below command (based on the file location on your system) on the master node.
@@ -942,13 +898,13 @@ groups:
 
   - id: 1.4.11
     text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
-    audit: ps -ef | grep $etcdbin | grep -v grep | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %a
+    audit: "ps -ef | grep $etcdbin | grep -v grep | grep -o data-dir=.* | cut -d= -f2 | xargs --no-run-if-empty stat -c %a"
     tests:
       test_items:
-      - flag: "700"
+      - flag: ""
         compare:
-          op: eq
-          value: "700"
+          op: lte
+          value: 700
         set: true
     remediation: |
       On the etcd server node, get the etcd data directory, passed as an argument --data-dir ,
@@ -980,21 +936,11 @@ groups:
     tests:
       bin_op: or
       test_items:
-        - flag: "644"
-          compare:
-            op: eq
-            value: "644"
-          set: true
-        - flag: "640"
-          compare:
-            op: eq
-            value: "640"
-          set: true
-        - flag: "600"
-          compare:
-            op: eq
-            value: "600"
-          set: true 
+      - flag: ""
+        compare:
+          op: lte
+          value: 644
+        set: true
     remediation: |
       Run the below command (based on the file location on your system) on the master node.
       For example,
@@ -1024,21 +970,11 @@ groups:
     tests:
       bin_op: or
       test_items:
-        - flag: "644"
-          compare:
-            op: eq
-            value: "644"
-          set: true
-        - flag: "640"
-          compare:
-            op: eq
-            value: "640"
-          set: true
-        - flag: "600"
-          compare:
-            op: eq
-            value: "600"
-          set: true
+      - flag: ""
+        compare:
+          op: lte
+          value: 644
+        set: true
     remediation: |
       Run the below command (based on the file location on your system) on the master node.
       For example,
@@ -1068,21 +1004,11 @@ groups:
     tests:
       bin_op: or
       test_items:
-        - flag: "644"
-          compare:
-            op: eq
-            value: "644"
-          set: true
-        - flag: "640"
-          compare:
-            op: eq
-            value: "640"
-          set: true
-        - flag: "600"
-          compare:
-            op: eq
-            value: "600"
-          set: true   
+      - flag: ""
+        compare:
+          op: lte
+          value: 644
+        set: true
     remediation: |
       Run the below command (based on the file location on your system) on the master node.
       For example,
@@ -1254,7 +1180,7 @@ groups:
       Then, edit the etcd pod specification file $etcdconf on the
       master node and set the below parameter.
       --trusted-ca-file=</path/to/ca-file>
-    scored: false 
+    scored: false
 
 - id: 1.6
   text: "General Security Primitives"
@@ -1292,7 +1218,7 @@ groups:
     scored: false
 
   - id: 1.6.5
-    text: "Ensure that the seccomp profile is set to docker/default in your pod 
+    text: "Ensure that the seccomp profile is set to docker/default in your pod
     definitions (Not Scored)"
     type: "manual"
     remediation: |

--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -1,5 +1,5 @@
 ---
-## Controls Files. 
+## Controls Files.
 # These are YAML files that hold all the details for running checks.
 #
 ## Uncomment to use different control file paths.
@@ -12,7 +12,7 @@ master:
     - apiserver
     - scheduler
     - controllermanager
-    - etcd 
+    - etcd
     - flanneld
     # kubernetes is a component to cover the config file /etc/kubernetes/config that is referred to in the benchmark
     - kubernetes
@@ -30,15 +30,26 @@ master:
       - /etc/kubernetes/apiserver
     defaultconf: /etc/kubernetes/apiserver
 
+    podspecs:
+      - /etc/kubernetes/manifests/kube-apiserver.yaml
+      - /etc/kubernetes/manifests/kube-apiserver.manifest
+    defaultpodspec: /etc/kubernetes/manifests/kube-apiserver.yaml
+
   scheduler:
     bins:
       - "kube-scheduler"
       - "hyperkube scheduler"
       - "scheduler"
-    confs: 
+    confs:
       - /etc/kubernetes/scheduler.conf
       - /etc/kubernetes/scheduler
+      - /var/lib/kube-scheduler/kubeconfig
     defaultconf: /etc/kubernetes/scheduler
+
+    podspecs:
+      - /etc/kubernetes/manifests/kube-scheduler.yaml
+      - /etc/kubernetes/manifests/kube-scheduler.manifest
+    defaultpodspec: /etc/kubernetes/manifests/kube-scheduler.yaml
 
   controllermanager:
     bins:
@@ -48,7 +59,13 @@ master:
     confs:
       - /etc/kubernetes/controller-manager.conf
       - /etc/kubernetes/controller-manager
+      - /var/lib/kube-controller-manager/kubeconfig
     defaultconf: /etc/kubernetes/controller-manager
+
+    podspecs:
+      - /etc/kubernetes/manifests/kube-controller-manager.yaml
+      - /etc/kubernetes/manifests/kube-controller-manager.manifest
+    defaultpodspec: /etc/kubernetes/manifests/kube-controller-manager.yaml
 
   etcd:
     optional: true
@@ -57,6 +74,11 @@ master:
     confs:
       - /etc/etcd/etcd.conf
     defaultconf: /etc/etcd/etcd.conf
+
+    podspecs:
+      - /etc/kubernetes/manifests/etcd.yaml
+      - /etc/kubernetes/manifests/etcd.manifest
+    defaultpodspec: /etc/kubernetes/manifests/etcd.yaml
 
   flanneld:
     optional: true
@@ -72,7 +94,7 @@ node:
     - kubernetes
 
   kubernetes:
-    defaultconf: /etc/kubernetes/config    
+    defaultconf: /etc/kubernetes/config
 
   kubelet:
     bins:
@@ -80,8 +102,12 @@ node:
       - "kubelet"
     confs:
       - /etc/kubernetes/kubelet.conf
-      - /etc/kubernetes/kubelet 
+      - /etc/kubernetes/kubelet
     defaultconf: "/etc/kubernetes/kubelet.conf"
+
+    unitfiles:
+     - /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+    defaultunitfile: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 
   proxy:
     bins:

--- a/check/check.go
+++ b/check/check.go
@@ -60,16 +60,16 @@ func handleError(err error, context string) (errmsg string) {
 // Check contains information about a recommendation in the
 // CIS Kubernetes 1.6+ document.
 type Check struct {
-	ID          string 		`yaml:"id" json:"test_number"`
-	Text        string		`json:"test_desc"`
+	ID          string      `yaml:"id" json:"test_number"`
+	Text        string      `json:"test_desc"`
 	Audit       string      `json:"omit"`
 	Type        string      `json:"type"`
 	Commands    []*exec.Cmd `json:"omit"`
 	Tests       *tests      `json:"omit"`
 	Set         bool        `json:"omit"`
-	Remediation string 		`json:"-"`
-	TestInfo    []string 	`json:"test_info"`
-	State 					`json:"status"`
+	Remediation string      `json:"-"`
+	TestInfo    []string    `json:"test_info"`
+	State       `json:"status"`
 }
 
 // Run executes the audit commands specified in a check and outputs
@@ -161,6 +161,7 @@ func (c *Check) Run() {
 		glog.V(2).Info(errmsgs)
 	}
 
+	glog.V(2).Info(fmt.Sprintf("Commands %#v output was '%s'\n", c.Commands, out.String()))
 	res := c.Tests.execute(out.String())
 	if res {
 		c.State = PASS

--- a/check/test.go
+++ b/check/test.go
@@ -20,6 +20,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/golang/glog"
 )
 
 // test:
@@ -51,7 +53,7 @@ type compare struct {
 
 func (t *testItem) execute(s string) (result bool) {
 	result = false
-	match := strings.Contains(s, t.Flag)
+	match := t.Flag == "" || strings.Contains(s, t.Flag)
 
 	if t.Set {
 		var flagVal string
@@ -78,6 +80,7 @@ func (t *testItem) execute(s string) (result bool) {
 				os.Exit(1)
 			}
 
+			glog.V(1).Info(fmt.Sprintf("Comparing '%s' '%s' '%s'\n", t.Compare.Op, flagVal, t.Compare.Value))
 			switch t.Compare.Op {
 			case "eq":
 				result = flagVal == t.Compare.Value
@@ -86,20 +89,36 @@ func (t *testItem) execute(s string) (result bool) {
 				result = !(flagVal == t.Compare.Value)
 
 			case "gt":
-				a, b := toNumeric(flagVal, t.Compare.Value)
-				result = a > b
+				if flagVal != "" {
+					a, b := toNumeric(flagVal, t.Compare.Value)
+					result = a > b
+				} else {
+					result = false
+				}
 
 			case "gte":
-				a, b := toNumeric(flagVal, t.Compare.Value)
-				result = a >= b
+				if flagVal != "" {
+					a, b := toNumeric(flagVal, t.Compare.Value)
+					result = a >= b
+				} else {
+					result = false
+				}
 
 			case "lt":
-				a, b := toNumeric(flagVal, t.Compare.Value)
-				result = a < b
+				if flagVal != "" {
+					a, b := toNumeric(flagVal, t.Compare.Value)
+					result = a < b
+				} else {
+					result = false
+				}
 
 			case "lte":
-				a, b := toNumeric(flagVal, t.Compare.Value)
-				result = a <= b
+				if flagVal != "" {
+					a, b := toNumeric(flagVal, t.Compare.Value)
+					result = a <= b
+				} else {
+					result = false
+				}
 
 			case "has":
 				result = strings.Contains(flagVal, t.Compare.Value)

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -275,7 +275,7 @@ func makeSubstitutions(s string, ext string, m map[string]string) string {
 			glog.V(2).Info(fmt.Sprintf("No subsitution for '%s'\n", subst))
 			continue
 		}
-		glog.V(1).Info(fmt.Sprintf("Substituting %s with '%s'\n", subst, v))
+		glog.V(1).Info(fmt.Sprintf("aaa Substituting %s with '%s'\n", subst, v))
 		s = multiWordReplace(s, subst, v)
 	}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 if [ -d /host ]; then
   mkdir -p /host/cfg/
-  yes | cp -rf /cfg/* /host/cfg/
-  yes | cp -rf /kube-bench /host/
+  yes | cp -rf ./cfg/* /host/cfg/
+  yes | cp -rf ./kube-bench /host/
   echo "==============================================="
   echo "kube-bench is now installed on your host       "
   echo "Run ./kube-bench to perform a security check   "
@@ -10,5 +10,5 @@ if [ -d /host ]; then
 else
   echo "Usage:"
   echo "  docker run --rm -v \`pwd\`:/host aquasec/kube-bench"
-  exit 
+  exit
 fi


### PR DESCRIPTION
This also adds support for updated tests such that "flag" can be empty,
indicating that the comparison should always happen. This helps ensure
that we can compare file permissions in a much better way.