### PR TITLE
Modification to support a kops installed Kubernetes

### DIFF
--- a/cfg/config.yaml
+++ b/cfg/config.yaml
@@ -1,5 +1,5 @@
 ---
-## Controls Files. 
+## Controls Files.
 # These are YAML files that hold all the details for running checks.
 #
 ## Uncomment to use different control file paths.
@@ -12,7 +12,7 @@ master:
     - apiserver
     - scheduler
     - controllermanager
-    - etcd 
+    - etcd
     - flanneld
     # kubernetes is a component to cover the config file /etc/kubernetes/config that is referred to in the benchmark
     - kubernetes
@@ -28,6 +28,7 @@ master:
     confs:
       - /etc/kubernetes/apiserver.conf
       - /etc/kubernetes/apiserver
+      - /etc/kubernetes/manifests/kube-apiserver.manifest
     defaultconf: /etc/kubernetes/apiserver
 
   scheduler:
@@ -35,9 +36,10 @@ master:
       - "kube-scheduler"
       - "hyperkube scheduler"
       - "scheduler"
-    confs: 
+    confs:
       - /etc/kubernetes/scheduler.conf
       - /etc/kubernetes/scheduler
+      - /var/lib/kube-scheduler/kubeconfig
     defaultconf: /etc/kubernetes/scheduler
 
   controllermanager:
@@ -48,6 +50,7 @@ master:
     confs:
       - /etc/kubernetes/controller-manager.conf
       - /etc/kubernetes/controller-manager
+      - /var/lib/kube-controller-manager/kubeconfig
     defaultconf: /etc/kubernetes/controller-manager
 
   etcd:
@@ -56,6 +59,7 @@ master:
       - "etcd"
     confs:
       - /etc/etcd/etcd.conf
+      - /etc/kubernetes/manifests/etcd.manifest
     defaultconf: /etc/etcd/etcd.conf
 
   flanneld:
@@ -72,7 +76,7 @@ node:
     - kubernetes
 
   kubernetes:
-    defaultconf: /etc/kubernetes/config    
+    defaultconf: /etc/kubernetes/config
 
   kubelet:
     bins:
@@ -80,7 +84,8 @@ node:
       - "kubelet"
     confs:
       - /etc/kubernetes/kubelet.conf
-      - /etc/kubernetes/kubelet 
+      - /etc/kubernetes/kubelet
+      - /etc/sysconfig/kubelet
     defaultconf: "/etc/kubernetes/kubelet.conf"
 
   proxy:
@@ -91,6 +96,7 @@ node:
     confs:
       - /etc/kubernetes/proxy.conf
       - /etc/kubernetes/proxy
+      - /etc/kubernetes/kube-proxy.manifest
       - /etc/kubernetes/addons/kube-proxy-daemonset.yaml
 
 federated:

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -131,41 +131,48 @@ func colorPrint(state check.State, s string) {
 
 // prettyPrint outputs the results to stdout in human-readable format
 func prettyPrint(r *check.Controls, summary check.Summary) {
-	colorPrint(check.INFO, fmt.Sprintf("%s %s\n", r.ID, r.Text))
-	for _, g := range r.Groups {
-		colorPrint(check.INFO, fmt.Sprintf("%s %s\n", g.ID, g.Text))
-		for _, c := range g.Checks {
-			colorPrint(c.State, fmt.Sprintf("%s %s\n", c.ID, c.Text))
-		}
-	}
-
-	fmt.Println()
-
-	// Print remediations.
-	if summary.Fail > 0 || summary.Warn > 0 {
-		colors[check.WARN].Printf("== Remediations ==\n")
+	// Print check results.
+	if !noResults {
+		colorPrint(check.INFO, fmt.Sprintf("%s %s\n", r.ID, r.Text))
 		for _, g := range r.Groups {
+			colorPrint(check.INFO, fmt.Sprintf("%s %s\n", g.ID, g.Text))
 			for _, c := range g.Checks {
-				if c.State != check.PASS {
-					fmt.Printf("%s %s\n", c.ID, c.Remediation)
-				}
+				colorPrint(c.State, fmt.Sprintf("%s %s\n", c.ID, c.Text))
 			}
 		}
+
 		fmt.Println()
 	}
 
-	// Print summary setting output color to highest severity.
-	var res check.State
-	if summary.Fail > 0 {
-		res = check.FAIL
-	} else if summary.Warn > 0 {
-		res = check.WARN
-	} else {
-		res = check.PASS
+	// Print remediations.
+	if !noRemediations {
+		if summary.Fail > 0 || summary.Warn > 0 {
+			colors[check.WARN].Printf("== Remediations ==\n")
+			for _, g := range r.Groups {
+				for _, c := range g.Checks {
+					if c.State != check.PASS {
+						fmt.Printf("%s %s\n", c.ID, c.Remediation)
+					}
+				}
+			}
+			fmt.Println()
+		}
 	}
 
-	colors[res].Printf("== Summary ==\n")
-	fmt.Printf("%d checks PASS\n%d checks FAIL\n%d checks WARN\n",
-		summary.Pass, summary.Fail, summary.Warn,
-	)
+	// Print summary setting output color to highest severity.
+	if !noSummary {
+		var res check.State
+		if summary.Fail > 0 {
+			res = check.FAIL
+		} else if summary.Warn > 0 {
+			res = check.WARN
+		} else {
+			res = check.PASS
+		}
+
+		colors[res].Printf("== Summary ==\n")
+		fmt.Printf("%d checks PASS\n%d checks FAIL\n%d checks WARN\n",
+			summary.Pass, summary.Fail, summary.Warn,
+		)
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,9 @@ var (
 	masterFile         string
 	nodeFile           string
 	federatedFile      string
+	noResults          bool
+	noSummary          bool
+	noRemediations     bool
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -60,8 +63,13 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
+	// Output control
+	RootCmd.PersistentFlags().BoolVar(&noResults, "noresults", false, "Disable prints of results section")
+	RootCmd.PersistentFlags().BoolVar(&noSummary, "nosummary", false, "Disable printing of summary section")
+	RootCmd.PersistentFlags().BoolVar(&noRemediations, "noremediations", false, "Disable printing of remediations section")
 	RootCmd.PersistentFlags().BoolVar(&jsonFmt, "json", false, "Prints the results as JSON")
 	RootCmd.PersistentFlags().BoolVar(&pgSQL, "pgsql", false, "Save the results to PostgreSQL")
+
 	RootCmd.PersistentFlags().StringVarP(
 		&checkList,
 		"check",


### PR DESCRIPTION
This also adds support for updated tests such that "flag" can be empty,
indicating that the comparison should always happen. This helps ensure
that we can compare file permissions in a much better way.